### PR TITLE
Allow secrets to be passed as files

### DIFF
--- a/internal/config.go
+++ b/internal/config.go
@@ -38,7 +38,7 @@ type Config struct {
 	MatchWhitelistOrDomain bool                 `long:"match-whitelist-or-domain" env:"MATCH_WHITELIST_OR_DOMAIN" description:"Allow users that match *either* whitelist or domain (enabled by default in v3)"`
 	Path                   string               `long:"url-path" env:"URL_PATH" default:"/_oauth" description:"Callback URL Path"`
 	SecretString           string               `long:"secret" env:"SECRET" description:"Secret used for signing (required)" json:"-"`
-	SecretFile             string               `long:"secret" env:"SECRET_FILE" description:"File holding the secret used for signing (required)" json:"-"`
+	SecretFile             string               `long:"secret-file" env:"SECRET_FILE" description:"File holding the secret used for signing (required)" json:"-"`
 	Whitelist              CommaSeparatedList   `long:"whitelist" env:"WHITELIST" env-delim:"," description:"Only allow given email addresses, can be set multiple times"`
 	Port                   int                  `long:"port" env:"PORT" default:"4181" description:"Port to listen on"`
 
@@ -259,7 +259,7 @@ func (c *Config) Validate() {
 		if len(c.SecretFile) == 0 {
 			log.Fatal("\"secret\" or \"secret-file\" option must be set")
 		}
-		secret, err := os.ReadFile(c.SecretFile)
+		secret, err := ioutil.ReadFile(c.SecretFile)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/internal/config.go
+++ b/internal/config.go
@@ -38,6 +38,7 @@ type Config struct {
 	MatchWhitelistOrDomain bool                 `long:"match-whitelist-or-domain" env:"MATCH_WHITELIST_OR_DOMAIN" description:"Allow users that match *either* whitelist or domain (enabled by default in v3)"`
 	Path                   string               `long:"url-path" env:"URL_PATH" default:"/_oauth" description:"Callback URL Path"`
 	SecretString           string               `long:"secret" env:"SECRET" description:"Secret used for signing (required)" json:"-"`
+	SecretFile             string               `long:"secret" env:"SECRET_FILE" description:"File holding the secret used for signing (required)" json:"-"`
 	Whitelist              CommaSeparatedList   `long:"whitelist" env:"WHITELIST" env-delim:"," description:"Only allow given email addresses, can be set multiple times"`
 	Port                   int                  `long:"port" env:"PORT" default:"4181" description:"Port to listen on"`
 
@@ -254,7 +255,15 @@ func convertLegacyToIni(name string) (io.Reader, error) {
 func (c *Config) Validate() {
 	// Check for show stopper errors
 	if len(c.Secret) == 0 {
-		log.Fatal("\"secret\" option must be set")
+		// try to read the secret from file
+		if len(c.SecretFile) == 0 {
+			log.Fatal("\"secret\" or \"secret-file\" option must be set")
+		}
+		secret, err := os.ReadFile(c.SecretFile)
+		if err != nil {
+			log.Fatal(err)
+		}
+		c.Secret = secret
 	}
 
 	// Setup default provider

--- a/internal/provider/generic_oauth.go
+++ b/internal/provider/generic_oauth.go
@@ -5,8 +5,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io/ioutil"
 	"net/http"
-	"os"
 
 	"golang.org/x/oauth2"
 )
@@ -32,17 +32,17 @@ func (o *GenericOAuth) Name() string {
 
 // Setup performs validation and setup
 func (o *GenericOAuth) Setup() error {
-	// Check parmas
-	if o.AuthURL == "" || o.TokenURL == "" || o.UserURL == "" || o.ClientID == "" || (o.ClientSecret == "" && o.ClientSecretFile == "") {
-		return errors.New("providers.generic-oauth.auth-url, providers.generic-oauth.token-url, providers.generic-oauth.user-url, providers.generic-oauth.client-id, providers.generic-oauth.client-secret[-file] must be set")
-	}
-
-	if len(o.ClientSecret) == 0 {
-		secret, err := os.ReadFile(o.ClientSecretFile)
+	if len(o.ClientSecretFile) > 0 {
+		secret, err := ioutil.ReadFile(o.ClientSecretFile)
 		if err != nil {
 			return err
 		}
 		o.ClientSecret = string(secret[:])
+	}
+
+	// Check parmas
+	if o.AuthURL == "" || o.TokenURL == "" || o.UserURL == "" || o.ClientID == "" || o.ClientSecret == "" {
+		return errors.New("providers.generic-oauth.auth-url, providers.generic-oauth.token-url, providers.generic-oauth.user-url, providers.generic-oauth.client-id, providers.generic-oauth.client-secret[-file] must be set")
 	}
 
 	// Create oauth2 config

--- a/internal/provider/oidc.go
+++ b/internal/provider/oidc.go
@@ -3,7 +3,7 @@ package provider
 import (
 	"context"
 	"errors"
-	"os"
+	"io/ioutil"
 
 	"github.com/coreos/go-oidc"
 	"golang.org/x/oauth2"
@@ -29,8 +29,16 @@ func (o *OIDC) Name() string {
 
 // Setup performs validation and setup
 func (o *OIDC) Setup() error {
+	if len(o.ClientSecretFile) > 0 {
+		secret, err := ioutil.ReadFile(o.ClientSecretFile)
+		if err != nil {
+			return err
+		}
+		o.ClientSecret = string(secret[:])
+	}
+
 	// Check parms
-	if o.IssuerURL == "" || o.ClientID == "" || (o.ClientSecret == "" && o.ClientSecretFile == "") {
+	if o.IssuerURL == "" || o.ClientID == "" || o.ClientSecret == "" {
 		return errors.New("providers.oidc.issuer-url, providers.oidc.client-id, providers.oidc.client-secret[-file] must be set")
 	}
 
@@ -41,14 +49,6 @@ func (o *OIDC) Setup() error {
 	o.provider, err = oidc.NewProvider(o.ctx, o.IssuerURL)
 	if err != nil {
 		return err
-	}
-
-	if len(o.ClientSecret) == 0 {
-		secret, err := os.ReadFile(o.ClientSecretFile)
-		if err != nil {
-			return err
-		}
-		o.ClientSecret = string(secret[:])
 	}
 
 	// Create oauth2 config


### PR DESCRIPTION
Current model either requires secrets to be exposed in the environment (or arguments) or generate a config.ini with the secrets embedded.

It is much easier to just accept the secrets as files.

This PR adds `secret-file`, `providers.oidc.client-secret-file` and `providers.generic-oauth.client-secret-file` configs which points to the files containing the secrets.